### PR TITLE
Add a fast path to `js_get_typedarray_info()` for off-heap views

### DIFF
--- a/src/js.cc
+++ b/src/js.cc
@@ -6203,6 +6203,29 @@ js_get_sharedarraybuffer_info(js_env_t *env, js_value_t *arraybuffer, void **dat
   return 0;
 }
 
+namespace {
+
+static inline void
+js_get_arraybufferview_info(Local<ArrayBufferView> view, void **data, size_t *len, js_value_t **arraybuffer, size_t *offset) {
+  if (data || arraybuffer) {
+    if (arraybuffer == nullptr && view->HasBuffer()) {
+      auto span = view->GetContents(MemorySpan<uint8_t>());
+
+      *data = span.data();
+    } else {
+      auto buffer = view->Buffer();
+
+      if (data) *data = static_cast<uint8_t *>(buffer->Data()) + view->ByteOffset();
+
+      if (arraybuffer) *arraybuffer = js_from_local(buffer);
+    }
+  }
+
+  if (offset) *offset = view->ByteOffset();
+}
+
+} // namespace
+
 extern "C" int
 js_get_typedarray_info(js_env_t *env, js_value_t *typedarray, js_typedarray_type_t *type, void **data, size_t *len, js_value_t **arraybuffer, size_t *offset) {
   // Allow continuing even with a pending exception
@@ -6239,15 +6262,7 @@ js_get_typedarray_info(js_env_t *env, js_value_t *typedarray, js_typedarray_type
 
   if (len) *len = local->Length();
 
-  Local<ArrayBuffer> buffer;
-
-  if (data || arraybuffer) buffer = local->Buffer();
-
-  if (data) *data = static_cast<uint8_t *>(buffer->Data()) + local->ByteOffset();
-
-  if (arraybuffer) *arraybuffer = js_from_local(buffer);
-
-  if (offset) *offset = local->ByteOffset();
+  js_get_arraybufferview_info(local, data, len, arraybuffer, offset);
 
   return 0;
 }
@@ -6260,15 +6275,7 @@ js_get_dataview_info(js_env_t *env, js_value_t *dataview, void **data, size_t *l
 
   if (len) *len = local->ByteLength();
 
-  Local<ArrayBuffer> buffer;
-
-  if (data || arraybuffer) buffer = local->Buffer();
-
-  if (data) *data = static_cast<uint8_t *>(buffer->Data()) + local->ByteOffset();
-
-  if (arraybuffer) *arraybuffer = js_from_local(buffer);
-
-  if (offset) *offset = local->ByteOffset();
+  js_get_arraybufferview_info(local, data, len, arraybuffer, offset);
 
   return 0;
 }

--- a/src/js.cc
+++ b/src/js.cc
@@ -6206,7 +6206,7 @@ js_get_sharedarraybuffer_info(js_env_t *env, js_value_t *arraybuffer, void **dat
 namespace {
 
 static inline void
-js_get_arraybufferview_info(Local<ArrayBufferView> view, void **data, size_t *len, js_value_t **arraybuffer, size_t *offset) {
+js_get_arraybufferview_info(Local<ArrayBufferView> view, void **data, js_value_t **arraybuffer, size_t *offset) {
   if (data || arraybuffer) {
     if (arraybuffer == nullptr && view->HasBuffer()) {
       auto span = view->GetContents(MemorySpan<uint8_t>());
@@ -6262,7 +6262,7 @@ js_get_typedarray_info(js_env_t *env, js_value_t *typedarray, js_typedarray_type
 
   if (len) *len = local->Length();
 
-  js_get_arraybufferview_info(local, data, len, arraybuffer, offset);
+  js_get_arraybufferview_info(local, data, arraybuffer, offset);
 
   return 0;
 }
@@ -6275,7 +6275,7 @@ js_get_dataview_info(js_env_t *env, js_value_t *dataview, void **data, size_t *l
 
   if (len) *len = local->ByteLength();
 
-  js_get_arraybufferview_info(local, data, len, arraybuffer, offset);
+  js_get_arraybufferview_info(local, data, arraybuffer, offset);
 
   return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -112,7 +112,9 @@ list(APPEND tests
   get-platform-version
   get-property-missing
   get-typedarray-info-uint16array
+  get-typedarray-info-uint16array-large
   get-typedarray-info-uint8array
+  get-typedarray-info-uint8array-large
   get-typedarray-info-uint8array-with-offset
   get-value-string-utf8
   get-value-string-utf8-length

--- a/test/get-typedarray-info-uint16array-large.c
+++ b/test/get-typedarray-info-uint16array-large.c
@@ -1,0 +1,59 @@
+#include <assert.h>
+#include <utf.h>
+#include <uv.h>
+
+#include "../include/js.h"
+
+int
+main() {
+  int e;
+
+  uv_loop_t *loop = uv_default_loop();
+
+  js_platform_t *platform;
+  e = js_create_platform(loop, NULL, &platform);
+  assert(e == 0);
+
+  js_env_t *env;
+  e = js_create_env(loop, platform, NULL, &env);
+  assert(e == 0);
+
+  js_handle_scope_t *scope;
+  e = js_open_handle_scope(env, &scope);
+  assert(e == 0);
+
+  js_value_t *script;
+  e = js_create_string_utf8(env, (utf8_t *) "new Uint16Array(1024).fill(42)", -1, &script);
+  assert(e == 0);
+
+  js_value_t *typedarray;
+  e = js_run_script(env, NULL, 0, 0, script, &typedarray);
+  assert(e == 0);
+
+  js_typedarray_type_t type;
+  uint16_t *data;
+  size_t len;
+  size_t offset;
+  e = js_get_typedarray_info(env, typedarray, &type, (void **) &data, &len, NULL, &offset);
+  assert(e == 0);
+
+  assert(type == js_uint16array);
+  assert(len == 1024);
+  assert(offset == 0);
+
+  for (int i = 0; i < len; i++) {
+    assert(data[i] == 42);
+  }
+
+  e = js_close_handle_scope(env, scope);
+  assert(e == 0);
+
+  e = js_destroy_env(env);
+  assert(e == 0);
+
+  e = js_destroy_platform(platform);
+  assert(e == 0);
+
+  e = uv_run(loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+}

--- a/test/get-typedarray-info-uint8array-large.c
+++ b/test/get-typedarray-info-uint8array-large.c
@@ -1,0 +1,59 @@
+#include <assert.h>
+#include <utf.h>
+#include <uv.h>
+
+#include "../include/js.h"
+
+int
+main() {
+  int e;
+
+  uv_loop_t *loop = uv_default_loop();
+
+  js_platform_t *platform;
+  e = js_create_platform(loop, NULL, &platform);
+  assert(e == 0);
+
+  js_env_t *env;
+  e = js_create_env(loop, platform, NULL, &env);
+  assert(e == 0);
+
+  js_handle_scope_t *scope;
+  e = js_open_handle_scope(env, &scope);
+  assert(e == 0);
+
+  js_value_t *script;
+  e = js_create_string_utf8(env, (utf8_t *) "new Uint8Array(1024).fill(42)", -1, &script);
+  assert(e == 0);
+
+  js_value_t *typedarray;
+  e = js_run_script(env, NULL, 0, 0, script, &typedarray);
+  assert(e == 0);
+
+  js_typedarray_type_t type;
+  uint8_t *data;
+  size_t len;
+  size_t offset;
+  e = js_get_typedarray_info(env, typedarray, &type, (void **) &data, &len, NULL, &offset);
+  assert(e == 0);
+
+  assert(type == js_uint8array);
+  assert(len == 1024);
+  assert(offset == 0);
+
+  for (int i = 0; i < len; i++) {
+    assert(data[i] == 42);
+  }
+
+  e = js_close_handle_scope(env, scope);
+  assert(e == 0);
+
+  e = js_destroy_env(env);
+  assert(e == 0);
+
+  e = js_destroy_platform(platform);
+  assert(e == 0);
+
+  e = uv_run(loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+}


### PR DESCRIPTION
This yields upwards of ~40% faster `js_get_typedarray_info()` calls in my tests.