### PR TITLE
Add `js_get_error_location()`

### DIFF
--- a/include/js.h
+++ b/include/js.h
@@ -35,6 +35,7 @@ typedef struct js_arraybuffer_backing_store_s js_arraybuffer_backing_store_t;
 typedef struct js_threadsafe_function_s js_threadsafe_function_t;
 typedef struct js_deferred_teardown_s js_deferred_teardown_t;
 typedef struct js_heap_statistics_s js_heap_statistics_t;
+typedef struct js_error_location_s js_error_location_t;
 typedef struct js_inspector_s js_inspector_t;
 
 typedef js_value_t *(*js_function_cb)(js_env_t *, js_callback_info_t *);
@@ -369,6 +370,23 @@ struct js_heap_statistics_s {
    * @since 1
    */
   size_t external_memory;
+};
+
+/** @version 0 */
+struct js_error_location_s {
+  int version;
+
+  /** @since 0 */
+  js_value_t *name;
+
+  /** @since 0 */
+  int64_t line;
+
+  /** @since 0 */
+  int64_t column_start;
+
+  /** @since 0 */
+  int64_t column_end;
 };
 
 int
@@ -770,6 +788,12 @@ js_create_syntax_error(js_env_t *env, js_value_t *code, js_value_t *message, js_
  */
 int
 js_create_reference_error(js_env_t *env, js_value_t *code, js_value_t *message, js_value_t **result);
+
+/**
+ * This function can be called even if there is a pending JavaScript exception.
+ */
+int
+js_get_error_location(js_env_t *env, js_value_t *error, js_error_location_t *result);
 
 /**
  * This function can be called even if there is a pending JavaScript exception.

--- a/include/js.h
+++ b/include/js.h
@@ -380,6 +380,9 @@ struct js_error_location_s {
   js_value_t *name;
 
   /** @since 0 */
+  js_value_t *source;
+
+  /** @since 0 */
   int64_t line;
 
   /** @since 0 */

--- a/src/js.cc
+++ b/src/js.cc
@@ -4574,6 +4574,20 @@ js_create_reference_error(js_env_t *env, js_value_t *code, js_value_t *message, 
 }
 
 extern "C" int
+js_get_error_location(js_env_t *env, js_value_t *error, js_error_location_t *result) {
+  auto context = env->current_context();
+
+  auto message = Exception::CreateMessage(env->isolate, js_to_local(error));
+
+  result->name = js_from_local(message->GetScriptResourceName());
+  result->line = message->GetLineNumber(context).FromJust();
+  result->column_start = message->GetStartColumn(context).FromJust();
+  result->column_end = message->GetEndColumn(context).FromJust();
+
+  return 0;
+}
+
+extern "C" int
 js_create_promise(js_env_t *env, js_deferred_t **deferred, js_value_t **promise) {
   // Allow continuing even with a pending exception
 

--- a/src/js.cc
+++ b/src/js.cc
@@ -4580,6 +4580,7 @@ js_get_error_location(js_env_t *env, js_value_t *error, js_error_location_t *res
   auto message = Exception::CreateMessage(env->isolate, js_to_local(error));
 
   result->name = js_from_local(message->GetScriptResourceName());
+  result->source = js_from_local(message->GetSource(context).ToLocalChecked());
   result->line = message->GetLineNumber(context).FromJust();
   result->column_start = message->GetStartColumn(context).FromJust();
   result->column_end = message->GetEndColumn(context).FromJust();

--- a/src/js.cc
+++ b/src/js.cc
@@ -4580,7 +4580,7 @@ js_get_error_location(js_env_t *env, js_value_t *error, js_error_location_t *res
   auto message = Exception::CreateMessage(env->isolate, js_to_local(error));
 
   result->name = js_from_local(message->GetScriptResourceName());
-  result->source = js_from_local(message->GetSource(context).ToLocalChecked());
+  result->source = js_from_local(message->GetSource(context).FromMaybe(Undefined(env->isolate)));
   result->line = message->GetLineNumber(context).FromJust();
   result->column_start = message->GetStartColumn(context).FromJust();
   result->column_end = message->GetEndColumn(context).FromJust();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,7 @@ list(APPEND tests
   fatal-exception
   get-arraybuffer-info
   get-dataview-info
+  get-error-location
   get-platform-identifier
   get-platform-limits
   get-platform-version

--- a/test/get-error-location.c
+++ b/test/get-error-location.c
@@ -1,0 +1,64 @@
+#include <assert.h>
+#include <utf.h>
+#include <uv.h>
+
+#include "../include/js.h"
+
+int
+main() {
+  int e;
+
+  uv_loop_t *loop = uv_default_loop();
+
+  js_platform_t *platform;
+  e = js_create_platform(loop, NULL, &platform);
+  assert(e == 0);
+
+  js_env_t *env;
+  e = js_create_env(loop, platform, NULL, &env);
+  assert(e == 0);
+
+  js_handle_scope_t *scope;
+  e = js_open_handle_scope(env, &scope);
+  assert(e == 0);
+
+  js_value_t *script;
+  e = js_create_string_utf8(env, (utf8_t *) "1 * 2 + ()", -1, &script);
+  assert(e == 0);
+
+  js_value_t *result;
+  e = js_run_script(env, "test.js", -1, 0, script, &result);
+  assert(e != 0);
+
+  js_value_t *error;
+  e = js_get_and_clear_last_exception(env, &error);
+  assert(e == 0);
+
+  js_error_location_t location = {.version = 0};
+  e = js_get_error_location(env, error, &location);
+  assert(e == 0);
+
+  utf8_t name[8];
+  e = js_get_value_string_utf8(env, location.name, name, 8, NULL);
+  assert(e == 0);
+
+  printf(
+    "name=%s line=%lld column=[%lld, %lld)\n",
+    name,
+    location.line,
+    location.column_start,
+    location.column_end
+  );
+
+  e = js_close_handle_scope(env, scope);
+  assert(e == 0);
+
+  e = js_destroy_env(env);
+  assert(e == 0);
+
+  e = js_destroy_platform(platform);
+  assert(e == 0);
+
+  e = uv_run(loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+}

--- a/test/get-error-location.c
+++ b/test/get-error-location.c
@@ -42,9 +42,14 @@ main() {
   e = js_get_value_string_utf8(env, location.name, name, 8, NULL);
   assert(e == 0);
 
+  utf8_t source[11];
+  e = js_get_value_string_utf8(env, location.source, source, 11, NULL);
+  assert(e == 0);
+
   printf(
-    "name=%s line=%lld column=[%lld, %lld)\n",
+    "name=%s\nsource=%s\nline=%lld\ncolumn=[%lld, %lld)\n",
     name,
+    source,
     location.line,
     location.column_start,
     location.column_end


### PR DESCRIPTION
Embedders, such as [Bare](https://github.com/holepunchto/bare), currently rely on the first frame of stack traces to communicate the source location of a given exception. For exceptions that happen prior to a frame being available, such as `SyntaxError`s thrown during script compilation, no source location is available, however. The `js_get_error_location()` API provides a way to explicitly request the source location of a given exception object, if available.