### PR TITLE
Add `js_get_heap_space_statistics`

### DIFF
--- a/include/js.h
+++ b/include/js.h
@@ -35,6 +35,7 @@ typedef struct js_arraybuffer_backing_store_s js_arraybuffer_backing_store_t;
 typedef struct js_threadsafe_function_s js_threadsafe_function_t;
 typedef struct js_deferred_teardown_s js_deferred_teardown_t;
 typedef struct js_heap_statistics_s js_heap_statistics_t;
+typedef struct js_heap_space_statistics_s js_heap_space_statistics_t;
 typedef struct js_inspector_s js_inspector_t;
 
 typedef js_value_t *(*js_function_cb)(js_env_t *, js_callback_info_t *);
@@ -369,6 +370,23 @@ struct js_heap_statistics_s {
    * @since 1
    */
   size_t external_memory;
+};
+
+/** @version 0 */
+struct js_heap_space_statistics_s {
+  int version;
+
+  /** @since 0 */
+  const char *space_name;
+
+  /** @since 0 */
+  size_t space_size;
+
+  /** @since 0 */
+  size_t space_used_size;
+
+  /** @since 0 */
+  size_t space_available_size;
 };
 
 int
@@ -1612,6 +1630,12 @@ js_request_garbage_collection(js_env_t *env);
  */
 int
 js_get_heap_statistics(js_env_t *env, js_heap_statistics_t *result);
+
+/**
+ * This function can be called even if there is a pending JavaScript exception.
+ */
+int
+js_get_heap_space_statistics(js_env_t *env, size_t *len, js_heap_space_statistics_t **result);
 
 int
 js_create_inspector(js_env_t *env, js_inspector_t **result);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,7 @@ list(APPEND tests
   fatal-exception
   get-arraybuffer-info
   get-dataview-info
+  get-heap-space-statistics
   get-platform-identifier
   get-platform-limits
   get-platform-version

--- a/test/get-heap-space-statistics.c
+++ b/test/get-heap-space-statistics.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <uv.h>
+
+#include "../include/js.h"
+
+int
+main() {
+  int e;
+
+  uv_loop_t *loop = uv_default_loop();
+
+  js_platform_t *platform;
+  e = js_create_platform(loop, NULL, &platform);
+  assert(e == 0);
+
+  js_env_t *env;
+  e = js_create_env(loop, platform, NULL, &env);
+  assert(e == 0);
+
+  js_handle_scope_t *scope;
+  e = js_open_handle_scope(env, &scope);
+  assert(e == 0);
+
+  size_t len;
+  js_heap_space_statistics_t *result;
+  e = js_get_heap_space_statistics(env, &len, &result);
+  assert(e == 0);
+
+  assert(len > 0);
+
+  e = js_close_handle_scope(env, scope);
+  assert(e == 0);
+
+  e = js_destroy_env(env);
+  assert(e == 0);
+
+  e = js_destroy_platform(platform);
+  assert(e == 0);
+
+  e = uv_run(loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+}


### PR DESCRIPTION
API used at: https://github.com/siimon/prom-client/blob/f6dc1a37486a93325a45fb1d3350460173ea9889/lib/metrics/heapSpacesSizeAndUsed.js#L39-L55 and intended to be used on `bare-v8` + `hyper-instrument`