### PR TITLE
Add Garbage Collection tracking

### DIFF
--- a/include/js.h
+++ b/include/js.h
@@ -422,14 +422,6 @@ struct js_error_location_s {
 };
 
 /** @version 0 */
-struct js_garbage_collection_tracking_s {
-  int version;
-
-  /** @since 0 */
-  void *data;
-};
-
-/** @version 0 */
 struct js_garbage_collection_tracking_options_s {
   int version;
 

--- a/include/js.h
+++ b/include/js.h
@@ -39,6 +39,7 @@ typedef struct js_heap_space_statistics_s js_heap_space_statistics_t;
 typedef struct js_error_location_s js_error_location_t;
 typedef struct js_inspector_s js_inspector_t;
 typedef struct js_garbage_collection_tracking_s js_garbage_collection_tracking_t;
+typedef struct js_garbage_collection_tracking_options_s js_garbage_collection_tracking_options_t;
 
 typedef js_value_t *(*js_function_cb)(js_env_t *, js_callback_info_t *);
 typedef void (*js_finalize_cb)(js_env_t *, void *data, void *finalize_hint);
@@ -425,13 +426,18 @@ struct js_garbage_collection_tracking_s {
   int version;
 
   /** @since 0 */
+  void *data;
+};
+
+/** @version 0 */
+struct js_garbage_collection_tracking_options_s {
+  int version;
+
+  /** @since 0 */
   js_garbage_collection_cb start_cb;
 
   /** @since 0 */
   js_garbage_collection_cb end_cb;
-
-  /** @since 0 */
-  void *data;
 };
 
 int
@@ -1697,13 +1703,13 @@ js_request_garbage_collection(js_env_t *env);
  * This function can be called even if there is a pending JavaScript exception.
  */
 int
-js_enable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *gc_tracking, void *data);
+js_enable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_options_t *options, void *data, js_garbage_collection_tracking_t **result);
 
 /**
  * This function can be called even if there is a pending JavaScript exception.
  */
 int
-js_disable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *gc_tracking);
+js_disable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *result);
 
 /**
  * This function can be called even if there is a pending JavaScript exception.

--- a/include/js.h
+++ b/include/js.h
@@ -180,7 +180,7 @@ typedef enum {
   js_garbage_collection_type_generational = 2
 } js_garbage_collection_type_t;
 
-typedef void (*js_garbage_collection_cb)(js_garbage_collection_type_t);
+typedef void (*js_garbage_collection_cb)(js_garbage_collection_type_t, void *data);
 
 /** @version 1 */
 struct js_platform_options_s {
@@ -429,6 +429,9 @@ struct js_garbage_collection_tracking_s {
 
   /** @since 0 */
   js_garbage_collection_cb end_cb;
+
+  /** @since 0 */
+  void *data;
 };
 
 int
@@ -1694,7 +1697,7 @@ js_request_garbage_collection(js_env_t *env);
  * This function can be called even if there is a pending JavaScript exception.
  */
 int
-js_enable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *gc_tracking);
+js_enable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *gc_tracking, void *data);
 
 /**
  * This function can be called even if there is a pending JavaScript exception.

--- a/include/js.h
+++ b/include/js.h
@@ -38,6 +38,7 @@ typedef struct js_heap_statistics_s js_heap_statistics_t;
 typedef struct js_heap_space_statistics_s js_heap_space_statistics_t;
 typedef struct js_error_location_s js_error_location_t;
 typedef struct js_inspector_s js_inspector_t;
+typedef struct js_garbage_collection_tracking_s js_garbage_collection_tracking_t;
 
 typedef js_value_t *(*js_function_cb)(js_env_t *, js_callback_info_t *);
 typedef void (*js_finalize_cb)(js_env_t *, void *data, void *finalize_hint);
@@ -173,6 +174,13 @@ typedef enum {
   js_threadsafe_function_nonblocking = 0,
   js_threadsafe_function_blocking = 1
 } js_threadsafe_function_call_mode_t;
+
+typedef enum {
+  js_garbage_collection_type_mark_compact = 1,
+  js_garbage_collection_type_generational = 2
+} js_garbage_collection_type_t;
+
+typedef void (*js_garbage_collection_cb)(js_garbage_collection_type_t);
 
 /** @version 1 */
 struct js_platform_options_s {
@@ -410,6 +418,17 @@ struct js_error_location_s {
 
   /** @since 0 */
   int64_t column_end;
+};
+
+/** @version 0 */
+struct js_garbage_collection_tracking_s {
+  int version;
+
+  /** @since 0 */
+  js_garbage_collection_cb start_cb;
+
+  /** @since 0 */
+  js_garbage_collection_cb end_cb;
 };
 
 int
@@ -1670,6 +1689,18 @@ js_adjust_external_memory(js_env_t *env, int64_t change_in_bytes, int64_t *resul
  */
 int
 js_request_garbage_collection(js_env_t *env);
+
+/**
+ * This function can be called even if there is a pending JavaScript exception.
+ */
+int
+js_enable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *gc_tracking);
+
+/**
+ * This function can be called even if there is a pending JavaScript exception.
+ */
+int
+js_disable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *gc_tracking);
 
 /**
  * This function can be called even if there is a pending JavaScript exception.

--- a/include/js.h
+++ b/include/js.h
@@ -426,10 +426,10 @@ struct js_garbage_collection_tracking_options_s {
   int version;
 
   /** @since 0 */
-  js_garbage_collection_cb start_cb;
+  js_garbage_collection_cb start;
 
   /** @since 0 */
-  js_garbage_collection_cb end_cb;
+  js_garbage_collection_cb end;
 };
 
 int
@@ -1695,13 +1695,13 @@ js_request_garbage_collection(js_env_t *env);
  * This function can be called even if there is a pending JavaScript exception.
  */
 int
-js_enable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_options_t *options, void *data, js_garbage_collection_tracking_t **result);
+js_enable_garbage_collection_tracking(js_env_t *env, const js_garbage_collection_tracking_options_t *options, void *data, js_garbage_collection_tracking_t **result);
 
 /**
  * This function can be called even if there is a pending JavaScript exception.
  */
 int
-js_disable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *result);
+js_disable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *tracking);
 
 /**
  * This function can be called even if there is a pending JavaScript exception.

--- a/src/js.cc
+++ b/src/js.cc
@@ -3041,6 +3041,9 @@ struct js_garbage_collection_tracking_s {
   js_garbage_collection_tracking_options_t options;
 
   void *data;
+
+  js_garbage_collection_tracking_s(js_garbage_collection_tracking_options_t options, void *data) : options(options),
+                                                                                                   data(data) {}
 };
 
 bool
@@ -7219,9 +7222,7 @@ extern "C" int
 js_enable_garbage_collection_tracking(js_env_t *env, const js_garbage_collection_tracking_options_t *options, void *data, js_garbage_collection_tracking_t **result) {
   // Allow continuing even with a pending exception
 
-  js_garbage_collection_tracking_t *gc_tracking = new js_garbage_collection_tracking_t();
-  gc_tracking->options = *options;
-  gc_tracking->data = data;
+  auto gc_tracking = new js_garbage_collection_tracking_t(*options, data);
 
   env->isolate->AddGCPrologueCallback(js_garbage_collection_tracking_prologue, static_cast<void *>(gc_tracking));
   env->isolate->AddGCEpilogueCallback(js_garbage_collection_tracking_epilogue, static_cast<void *>(gc_tracking));

--- a/src/js.cc
+++ b/src/js.cc
@@ -7194,7 +7194,7 @@ js_garbage_collection_tracking_prologue(Isolate *isolate, GCType type, GCCallbac
 
   js_garbage_collection_tracking_t *gc_tracking = static_cast<js_garbage_collection_tracking_t *>(data);
 
-  gc_tracking->start_cb(t);
+  gc_tracking->start_cb(t, gc_tracking->data);
 }
 
 static void
@@ -7207,12 +7207,14 @@ js_garbage_collection_tracking_epilogue(Isolate *isolate, GCType type, GCCallbac
 
   js_garbage_collection_tracking_t *gc_tracking = static_cast<js_garbage_collection_tracking_t *>(data);
 
-  gc_tracking->end_cb(t);
+  gc_tracking->end_cb(t, gc_tracking->data);
 }
 
 extern "C" int
-js_enable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *gc_tracking) {
+js_enable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *gc_tracking, void *data) {
   // Allow continuing even with a pending exception
+
+  gc_tracking->data = data;
 
   env->isolate->AddGCPrologueCallback(js_garbage_collection_tracking_prologue, static_cast<void *>(gc_tracking));
   env->isolate->AddGCEpilogueCallback(js_garbage_collection_tracking_epilogue, static_cast<void *>(gc_tracking));

--- a/src/js.cc
+++ b/src/js.cc
@@ -3040,30 +3040,21 @@ struct js_inspector_s {
   }
 };
 
+struct js_garbage_collection_tracking_s {
+  js_garbage_collection_tracking_options_s *options;
+
+  void *data;
+
+  js_garbage_collection_tracking_s(js_garbage_collection_tracking_options_s *options, void *data) : options(options),
+                                                                                                    data(data) {}
+};
+
 bool
 js_inspector_client_s::on_pause(js_inspector_t *session) {
   if (session->cb == nullptr) return false;
 
   return session->cb(session->env, session, session->data);
 }
-
-struct js_garbage_collection_tracking_callback_data_s {
-  js_garbage_collection_cb cb;
-
-  void *data;
-
-  js_garbage_collection_tracking_callback_data_s(js_garbage_collection_cb cb, void *data) : cb(cb),
-                                                                                            data(data) {}
-};
-
-struct js_garbage_collection_tracking_callbacks_data_s {
-  js_garbage_collection_tracking_callback_data_t *prologue;
-
-  js_garbage_collection_tracking_callback_data_t *epilogue;
-
-  js_garbage_collection_tracking_callbacks_data_s(js_garbage_collection_tracking_callback_data_t *prologue, js_garbage_collection_tracking_callback_data_t *epilogue) : prologue(prologue),
-                                                                                                                                                                        epilogue(epilogue) {}
-};
 
 namespace {
 
@@ -7205,32 +7196,40 @@ js_request_garbage_collection(js_env_t *env) {
 }
 
 static void
-js_garbage_collection_tracking_callback(Isolate *isolate, GCType type, GCCallbackFlags flags, void *data) {
+js_garbage_collection_tracking_prologue(Isolate *isolate, GCType type, GCCallbackFlags flags, void *data) {
   js_garbage_collection_type_t t;
 
   if (type == v8::GCType::kGCTypeScavenge) t = js_garbage_collection_type_t::js_garbage_collection_type_generational;
   else if (type == v8::GCType::kGCTypeMarkSweepCompact) t = js_garbage_collection_type_t::js_garbage_collection_type_mark_compact;
   else return;
 
-  js_garbage_collection_tracking_callback_data_t *cb_data = static_cast<js_garbage_collection_tracking_callback_data_t *>(data);
+  js_garbage_collection_tracking_t *gc_tracking = static_cast<js_garbage_collection_tracking_t *>(data);
 
-  cb_data->cb(t, cb_data->data);
+  gc_tracking->options->start_cb(t, gc_tracking->data);
+}
+
+static void
+js_garbage_collection_tracking_epilogue(Isolate *isolate, GCType type, GCCallbackFlags flags, void *data) {
+  js_garbage_collection_type_t t;
+
+  if (type == v8::GCType::kGCTypeScavenge) t = js_garbage_collection_type_t::js_garbage_collection_type_generational;
+  else if (type == v8::GCType::kGCTypeMarkSweepCompact) t = js_garbage_collection_type_t::js_garbage_collection_type_mark_compact;
+  else return;
+
+  js_garbage_collection_tracking_t *gc_tracking = static_cast<js_garbage_collection_tracking_t *>(data);
+
+  gc_tracking->options->end_cb(t, gc_tracking->data);
 }
 
 extern "C" int
 js_enable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_options_t *options, void *data, js_garbage_collection_tracking_t **result) {
   // Allow continuing even with a pending exception
 
-  auto prologue = new js_garbage_collection_tracking_callback_data_t(options->start_cb, data);
-  auto epilogue = new js_garbage_collection_tracking_callback_data_t(options->end_cb, data);
+  auto gc_tracking = new js_garbage_collection_tracking_t(options, data);
 
-  auto callbacks_data = new js_garbage_collection_tracking_callbacks_data_t(prologue, epilogue);
+  env->isolate->AddGCPrologueCallback(js_garbage_collection_tracking_prologue, static_cast<void *>(gc_tracking));
+  env->isolate->AddGCEpilogueCallback(js_garbage_collection_tracking_epilogue, static_cast<void *>(gc_tracking));
 
-  env->isolate->AddGCPrologueCallback(js_garbage_collection_tracking_callback, static_cast<void *>(callbacks_data->prologue));
-  env->isolate->AddGCEpilogueCallback(js_garbage_collection_tracking_callback, static_cast<void *>(callbacks_data->epilogue));
-
-  js_garbage_collection_tracking_t *gc_tracking = new js_garbage_collection_tracking_t();
-  gc_tracking->data = callbacks_data;
   *result = gc_tracking;
 
   return 0;
@@ -7240,10 +7239,8 @@ extern "C" int
 js_disable_garbage_collection_tracking(js_env_t *env, js_garbage_collection_tracking_t *result) {
   // Allow continuing even with a pending exception
 
-  js_garbage_collection_tracking_callbacks_data_t *callbacks_data = static_cast<js_garbage_collection_tracking_callbacks_data_t *>(result->data);
-
-  env->isolate->RemoveGCPrologueCallback(js_garbage_collection_tracking_callback, static_cast<void *>(callbacks_data->prologue));
-  env->isolate->RemoveGCEpilogueCallback(js_garbage_collection_tracking_callback, static_cast<void *>(callbacks_data->epilogue));
+  env->isolate->RemoveGCPrologueCallback(js_garbage_collection_tracking_prologue, static_cast<void *>(result));
+  env->isolate->RemoveGCEpilogueCallback(js_garbage_collection_tracking_epilogue, static_cast<void *>(result));
 
   delete result;
 

--- a/src/js.cc
+++ b/src/js.cc
@@ -7188,7 +7188,7 @@ static void
 js_garbage_collection_tracking_prologue(Isolate *isolate, GCType type, GCCallbackFlags flags, void *data) {
   js_garbage_collection_type_t t;
 
-  if (type == v8::GCType::kGCTypeScavenge) t = js_garbage_collection_type_t::js_garbage_collection_type_mark_compact;
+  if (type == v8::GCType::kGCTypeScavenge) t = js_garbage_collection_type_t::js_garbage_collection_type_generational;
   else if (type == v8::GCType::kGCTypeMarkSweepCompact) t = js_garbage_collection_type_t::js_garbage_collection_type_mark_compact;
   else return;
 
@@ -7201,7 +7201,7 @@ static void
 js_garbage_collection_tracking_epilogue(Isolate *isolate, GCType type, GCCallbackFlags flags, void *data) {
   js_garbage_collection_type_t t;
 
-  if (type == v8::GCType::kGCTypeScavenge) t = js_garbage_collection_type_t::js_garbage_collection_type_mark_compact;
+  if (type == v8::GCType::kGCTypeScavenge) t = js_garbage_collection_type_t::js_garbage_collection_type_generational;
   else if (type == v8::GCType::kGCTypeMarkSweepCompact) t = js_garbage_collection_type_t::js_garbage_collection_type_mark_compact;
   else return;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,7 @@ list(APPEND tests
   dynamic-import-with-promise
   dynamic-import-without-handler
   fatal-exception
+  garbage-collection-tracking
   get-arraybuffer-info
   get-dataview-info
   get-error-location

--- a/test/garbage-collection-tracking.c
+++ b/test/garbage-collection-tracking.c
@@ -42,12 +42,13 @@ main() {
   e = js_open_handle_scope(env, &scope);
   assert(e == 0);
 
-  js_garbage_collection_tracking_t gc_tracking = {
+  js_garbage_collection_tracking_options_t gc_tracking_options = {
     .start_cb = on_start,
     .end_cb = on_end,
   };
 
-  e = js_enable_garbage_collection_tracking(env, &gc_tracking, (void *) 42);
+  js_garbage_collection_tracking_t *gc_tracking;
+  e = js_enable_garbage_collection_tracking(env, &gc_tracking_options, (void *) 42, &gc_tracking);
   assert(e == 0);
 
   e = js_request_garbage_collection(env);
@@ -57,7 +58,7 @@ main() {
 
   assert(gc_end_called);
 
-  e = js_disable_garbage_collection_tracking(env, &gc_tracking);
+  e = js_disable_garbage_collection_tracking(env, gc_tracking);
   assert(e == 0);
 
   e = js_close_handle_scope(env, scope);

--- a/test/garbage-collection-tracking.c
+++ b/test/garbage-collection-tracking.c
@@ -1,0 +1,69 @@
+#include <assert.h>
+#include <uv.h>
+
+#include "../include/js.h"
+
+static bool gc_start_called = false;
+static bool gc_end_called = false;
+
+static void
+on_start(js_garbage_collection_type_t type) {
+  gc_start_called = true;
+}
+
+static void
+on_end(js_garbage_collection_type_t type) {
+  gc_end_called = true;
+}
+
+int
+main() {
+  int e;
+
+  uv_loop_t *loop = uv_default_loop();
+
+  js_platform_options_t options = {
+    .expose_garbage_collection = true,
+  };
+
+  js_platform_t *platform;
+  e = js_create_platform(loop, &options, &platform);
+  assert(e == 0);
+
+  js_env_t *env;
+  e = js_create_env(loop, platform, NULL, &env);
+  assert(e == 0);
+
+  js_handle_scope_t *scope;
+  e = js_open_handle_scope(env, &scope);
+  assert(e == 0);
+
+  js_garbage_collection_tracking_t gc_tracking = {
+    .start_cb = on_start,
+    .end_cb = on_end,
+  };
+
+  e = js_enable_garbage_collection_tracking(env, &gc_tracking);
+  assert(e == 0);
+
+  e = js_request_garbage_collection(env);
+  assert(e == 0);
+
+  assert(gc_start_called);
+  assert(gc_end_called);
+
+  e = js_disable_garbage_collection_tracking(env, &gc_tracking);
+  assert(e == 0);
+
+  e = js_close_handle_scope(env, scope);
+  assert(e == 0);
+
+  e = js_destroy_env(env);
+  assert(e == 0);
+
+  e = js_destroy_platform(platform);
+  assert(e == 0);
+
+  e = uv_run(loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+}

--- a/test/garbage-collection-tracking.c
+++ b/test/garbage-collection-tracking.c
@@ -7,13 +7,17 @@ static bool gc_start_called = false;
 static bool gc_end_called = false;
 
 static void
-on_start(js_garbage_collection_type_t type) {
+on_start(js_garbage_collection_type_t type, void *data) {
   gc_start_called = true;
+
+  assert((intptr_t) data == 42);
 }
 
 static void
-on_end(js_garbage_collection_type_t type) {
+on_end(js_garbage_collection_type_t type, void *data) {
   gc_end_called = true;
+
+  assert((intptr_t) data == 42);
 }
 
 int
@@ -43,13 +47,14 @@ main() {
     .end_cb = on_end,
   };
 
-  e = js_enable_garbage_collection_tracking(env, &gc_tracking);
+  e = js_enable_garbage_collection_tracking(env, &gc_tracking, (void *) 42);
   assert(e == 0);
 
   e = js_request_garbage_collection(env);
   assert(e == 0);
 
   assert(gc_start_called);
+
   assert(gc_end_called);
 
   e = js_disable_garbage_collection_tracking(env, &gc_tracking);

--- a/test/garbage-collection-tracking.c
+++ b/test/garbage-collection-tracking.c
@@ -42,9 +42,9 @@ main() {
   e = js_open_handle_scope(env, &scope);
   assert(e == 0);
 
-  js_garbage_collection_tracking_options_t gc_tracking_options = {
-    .start_cb = on_start,
-    .end_cb = on_end,
+  const js_garbage_collection_tracking_options_t gc_tracking_options = {
+    .start = on_start,
+    .end = on_end,
   };
 
   js_garbage_collection_tracking_t *gc_tracking;


### PR DESCRIPTION
Exposes AddGCPrologueCallback, AddGCEpilogueCallback, RemoveGCEpilogueCallback and RemoveGCEpilogueCallback.

---

Motivated by this quote from https://stackoverflow.com/a/60172044:

> "IncrementalMarking" and "ProcessWeakCallbacks" are not types of GC, but phases of major GC cycles. (I don't know why that enum happens to be called GCType, probably for historical reasons.)

I exposed only the actual types of GC: `GCTypeMarkSweepCompact` and `GCTypeScavenge`; Respectively also referred to as Major and Minor.

I tried to choose more generic names for those types: Mark-Compact and Generational, to avoid having names too specific to V8. I don't have strong opinions on this, feel free to inform which terms fit better.
