### PR TITLE
Fix `CFunction` lifetime

### DIFF
--- a/src/js.cc
+++ b/src/js.cc
@@ -2317,14 +2317,14 @@ struct js_typed_callback_s : js_callback_t {
   CTypeInfo result;
   std::vector<CTypeInfo> args;
   CFunctionInfo type;
-  const void *address;
+  CFunction function;
 
   js_typed_callback_s(js_env_t *env, js_function_cb cb, void *data, CTypeInfo result, std::vector<CTypeInfo> args, const void *address, CFunctionInfo::Int64Representation integer_representation)
       : js_callback_t(env, cb, data),
         result(std::move(result)),
         args(std::move(args)),
         type(this->result, uint16_t(this->args.size()), this->args.data(), integer_representation),
-        address(address) {}
+        function(address, &this->type) {}
 
   js_typed_callback_s(const js_typed_callback_s &) = delete;
 
@@ -2333,8 +2333,6 @@ struct js_typed_callback_s : js_callback_t {
 
   Local<FunctionTemplate>
   to_function_template(Isolate *isolate, Local<Signature> signature = Local<Signature>()) {
-    auto function = CFunction(address, &type);
-
     return FunctionTemplate::New(
       isolate,
       on_call,


### PR DESCRIPTION
A recent V8 change caused a pointer to the `CFunction` to be stored rather than copying it so it must now outlive the generated function template.