### PR TITLE
test(inspector): test report progress case

### DIFF
--- a/src/js.cc
+++ b/src/js.cc
@@ -59,6 +59,11 @@ typedef struct js_env_scope_s js_env_scope_t;
 typedef struct js_env_scope_options_s js_env_scope_options_t;
 typedef struct js_microtask_s js_microtask_t;
 
+// Delivers any inspector protocol messages that were queued while it was unsafe
+// to re-enter JavaScript.
+static void
+js__flush_inspector(js_env_t *env);
+
 typedef enum {
   js_task_nestable,
   js_task_non_nestable,
@@ -1675,6 +1680,11 @@ struct js_env_s {
 
       tasks->depth--;
     }
+
+    // Deliver any inspector messages that were queued while a task ran (e.g.
+    // heap snapshot progress and chunk notifications emitted during snapshot
+    // generation). We are now at a safe point to re-enter JavaScript.
+    js__flush_inspector(this);
   }
 
   bool
@@ -3012,12 +3022,34 @@ struct js_inspector_channel_s : public V8Inspector::Channel {
       : env(env),
         inspector(inspector),
         cb(),
-        data() {}
+        data(),
+        pending() {}
 
   js_inspector_channel_s(const js_inspector_channel_s &) = delete;
 
   js_inspector_channel_s &
   operator=(const js_inspector_channel_s &) = delete;
+
+  void
+  flush() {
+    auto cb = this->cb;
+
+    if (cb == nullptr) {
+      pending.clear();
+      return;
+    }
+
+    auto env = this->env;
+    auto inspector = this->inspector;
+    auto data = this->data;
+
+    auto batch = std::move(pending);
+    pending.clear();
+
+    for (auto &message : batch) {
+      cb(env, inspector, reinterpret_cast<char *>(message.data()), message.size() - 1, data);
+    }
+  }
 
 private: // V8 embedder API
   void
@@ -3040,7 +3072,8 @@ private: // V8 embedder API
       utf16le_convert_to_utf8(reinterpret_cast<const utf16_t *>(string.characters16()), string.length(), utf8.data());
     }
 
-    cb(env, inspector, reinterpret_cast<char *>(utf8.data()), utf8.size() - 1 /* NULL */, data);
+    // Queue the message in order and let `js__flush_inspector()` deliver it from a safe point.
+    pending.push_back(std::move(utf8));
   }
 
   void
@@ -3055,6 +3088,9 @@ private: // V8 embedder API
 
   void
   flushProtocolNotifications() override {}
+
+private:
+  std::deque<std::vector<utf8_t>> pending;
 };
 
 struct js_inspector_client_s : public V8InspectorClient {
@@ -3177,6 +3213,8 @@ struct js_inspector_s {
     utf8_convert_to_utf16le(reinterpret_cast<const utf8_t *>(message), len, utf16.data());
 
     session->dispatchProtocolMessage(StringView(utf16.data(), utf16_len));
+
+    channel.flush();
   }
 };
 
@@ -3185,6 +3223,24 @@ js_inspector_client_s::on_pause(js_inspector_t *session) {
   if (session->cb == nullptr) return false;
 
   return session->cb(session->env, session, session->data);
+}
+
+static void
+js__flush_inspector(js_env_t *env) {
+  if (env->inspector == nullptr) return;
+
+  auto sessions = std::vector<js_inspector_t *>(
+    env->inspector->sessions.begin(),
+    env->inspector->sessions.end()
+  );
+
+  for (auto session : sessions) {
+    auto &live = env->inspector->sessions;
+
+    if (std::find(live.begin(), live.end(), session) == live.end()) continue;
+
+    session->channel.flush();
+  }
 }
 
 struct js_garbage_collection_tracking_s {

--- a/src/js.cc
+++ b/src/js.cc
@@ -3030,26 +3030,14 @@ struct js_inspector_channel_s : public V8Inspector::Channel {
   js_inspector_channel_s &
   operator=(const js_inspector_channel_s &) = delete;
 
-  void
-  flush() {
-    auto cb = this->cb;
-
-    if (cb == nullptr) {
-      pending.clear();
-      return;
-    }
-
-    auto env = this->env;
-    auto inspector = this->inspector;
-    auto data = this->data;
-
-    auto batch = std::move(pending);
-    pending.clear();
-
-    for (auto &message : batch) {
-      cb(env, inspector, reinterpret_cast<char *>(message.data()), message.size() - 1, data);
-    }
+  bool
+  has_pending() {
+    return !pending.empty();
   }
+
+  // Defined out of line once `js_inspector_t` is complete.
+  void
+  flush();
 
 private: // V8 embedder API
   void
@@ -3086,6 +3074,8 @@ private: // V8 embedder API
     send(message->string());
   }
 
+  // Intentionally a no-op: V8 may call this from contexts where JavaScript
+  // execution is disallowed, e.g. from within heap snapshot generation.
   void
   flushProtocolNotifications() override {}
 
@@ -3225,17 +3215,61 @@ js_inspector_client_s::on_pause(js_inspector_t *session) {
   return session->cb(session->env, session, session->data);
 }
 
+void
+js_inspector_channel_s::flush() {
+  auto cb = this->cb;
+
+  if (cb == nullptr) {
+    pending.clear();
+    return;
+  }
+
+  auto env = this->env;
+  auto inspector = this->inspector;
+  auto data = this->data;
+
+  // Keep the client alive so the session list remains valid across callbacks.
+  auto client = inspector->client;
+
+  auto batch = std::move(pending);
+  pending.clear();
+
+  for (auto &message : batch) {
+    // Stop if a callback destroyed the session; the remaining messages have no
+    // valid receiver.
+    auto &live = client->sessions;
+
+    if (std::find(live.begin(), live.end(), inspector) == live.end()) return;
+
+    cb(env, inspector, reinterpret_cast<char *>(message.data()), message.size() - 1, data);
+  }
+}
+
 static void
 js__flush_inspector(js_env_t *env) {
   if (env->inspector == nullptr) return;
 
+  // Keep the client alive so the session list remains valid across callbacks.
+  auto client = env->inspector;
+
+  auto any = false;
+
+  for (auto session : client->sessions) {
+    if (session->channel.has_pending()) {
+      any = true;
+      break;
+    }
+  }
+
+  if (!any) return;
+
   auto sessions = std::vector<js_inspector_t *>(
-    env->inspector->sessions.begin(),
-    env->inspector->sessions.end()
+    client->sessions.begin(),
+    client->sessions.end()
   );
 
   for (auto session : sessions) {
-    auto &live = env->inspector->sessions;
+    auto &live = client->sessions;
 
     if (std::find(live.begin(), live.end(), session) == live.end()) continue;
 

--- a/src/js.cc
+++ b/src/js.cc
@@ -59,8 +59,7 @@ typedef struct js_env_scope_s js_env_scope_t;
 typedef struct js_env_scope_options_s js_env_scope_options_t;
 typedef struct js_microtask_s js_microtask_t;
 
-// Delivers any inspector protocol messages that were queued while it was unsafe
-// to re-enter JavaScript.
+// Delivers inspector messages queued while re-entering JavaScript was unsafe.
 static void
 js__flush_inspector(js_env_t *env);
 
@@ -1681,9 +1680,8 @@ struct js_env_s {
       tasks->depth--;
     }
 
-    // Deliver any inspector messages that were queued while a task ran (e.g.
-    // heap snapshot progress and chunk notifications emitted during snapshot
-    // generation). We are now at a safe point to re-enter JavaScript.
+    // Between tasks it is safe to re-enter JavaScript, so deliver any inspector
+    // messages queued while a task ran (e.g. heap snapshot progress).
     js__flush_inspector(this);
   }
 
@@ -3035,7 +3033,6 @@ struct js_inspector_channel_s : public V8Inspector::Channel {
     return !pending.empty();
   }
 
-  // Defined out of line once `js_inspector_t` is complete.
   void
   flush();
 
@@ -3060,7 +3057,7 @@ private: // V8 embedder API
       utf16le_convert_to_utf8(reinterpret_cast<const utf16_t *>(string.characters16()), string.length(), utf8.data());
     }
 
-    // Queue the message in order and let `js__flush_inspector()` deliver it from a safe point.
+    // Queue in order; `js__flush_inspector()` delivers from a safe point.
     pending.push_back(std::move(utf8));
   }
 
@@ -3074,8 +3071,8 @@ private: // V8 embedder API
     send(message->string());
   }
 
-  // Intentionally a no-op: V8 may call this from contexts where JavaScript
-  // execution is disallowed, e.g. from within heap snapshot generation.
+  // No-op on purpose: V8 may call this while re-entering JavaScript is unsafe,
+  // e.g. during heap snapshot generation.
   void
   flushProtocolNotifications() override {}
 
@@ -3228,15 +3225,14 @@ js_inspector_channel_s::flush() {
   auto inspector = this->inspector;
   auto data = this->data;
 
-  // Keep the client alive so the session list remains valid across callbacks.
+  // Hold the client alive: a callback may destroy the last session.
   auto client = inspector->client;
 
   auto batch = std::move(pending);
   pending.clear();
 
   for (auto &message : batch) {
-    // Stop if a callback destroyed the session; the remaining messages have no
-    // valid receiver.
+    // A previous callback may have destroyed the session; don't deliver to it.
     auto &live = client->sessions;
 
     if (std::find(live.begin(), live.end(), inspector) == live.end()) return;
@@ -3249,7 +3245,7 @@ static void
 js__flush_inspector(js_env_t *env) {
   if (env->inspector == nullptr) return;
 
-  // Keep the client alive so the session list remains valid across callbacks.
+  // Hold the client alive: a callback may destroy the last session.
   auto client = env->inspector;
 
   auto any = false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,6 +179,7 @@ list(APPEND tests
   import-meta-throw
   inspector
   inspector-attach-context
+  inspector-destroy-during-flush
   inspector-heap-snapshot-report-progress
   inspector-multiple-debugger-enable
   inspector-pause

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,6 +179,7 @@ list(APPEND tests
   import-meta-throw
   inspector
   inspector-attach-context
+  inspector-heap-snapshot-report-progress
   inspector-multiple-debugger-enable
   inspector-pause
   is-arguments

--- a/test/inspector-destroy-during-flush.c
+++ b/test/inspector-destroy-during-flush.c
@@ -1,0 +1,101 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <utf.h>
+#include <uv.h>
+
+#include "../include/js.h"
+
+// Regression test: a response callback that destroys the inspector sessions
+// while queued messages are still being delivered must not crash the runtime.
+
+static js_inspector_t *a = NULL;
+static js_inspector_t *b = NULL;
+
+static bool destroyed = false;
+
+static void
+on_response(js_env_t *env, js_inspector_t *inspector, const char *message, size_t len, void *data) {
+  int e;
+
+  if (destroyed) return;
+
+  if (strstr(message, "addHeapSnapshotChunk") != NULL) {
+    destroyed = true;
+
+    e = js_destroy_inspector(env, a);
+    assert(e == 0);
+
+    e = js_destroy_inspector(env, b);
+    assert(e == 0);
+  }
+}
+
+int
+main() {
+  int e;
+
+  uv_loop_t *loop = uv_default_loop();
+
+  js_platform_t *platform;
+  e = js_create_platform(loop, NULL, &platform);
+  assert(e == 0);
+
+  js_env_t *env;
+  e = js_create_env(loop, platform, NULL, &env);
+  assert(e == 0);
+
+  js_handle_scope_t *scope;
+  e = js_open_handle_scope(env, &scope);
+  assert(e == 0);
+
+  e = js_create_inspector(env, &a);
+  assert(e == 0);
+
+  e = js_on_inspector_response(env, a, on_response, NULL);
+  assert(e == 0);
+
+  e = js_connect_inspector(env, a);
+  assert(e == 0);
+
+  e = js_create_inspector(env, &b);
+  assert(e == 0);
+
+  e = js_on_inspector_response(env, b, on_response, NULL);
+  assert(e == 0);
+
+  e = js_connect_inspector(env, b);
+  assert(e == 0);
+
+  const char *enable = "{ \"id\": 1, \"method\": \"HeapProfiler.enable\" }";
+
+  e = js_send_inspector_request(env, a, enable, -1);
+  assert(e == 0);
+
+  // reportProgress schedules the snapshot as a task, so its messages are
+  // delivered from the macrotask flush point, where the first chunk callback
+  // destroys both sessions while more messages are still queued.
+  const char *snapshot = "{ \"id\": 2, \"method\": \"HeapProfiler.takeHeapSnapshot\", \"params\": { \"reportProgress\": true } }";
+
+  e = js_send_inspector_request(env, a, snapshot, -1);
+  assert(e == 0);
+
+  for (int i = 0; i < 10000 && !destroyed; i++) {
+    uv_run(loop, UV_RUN_NOWAIT);
+  }
+
+  assert(destroyed);
+
+  e = js_close_handle_scope(env, scope);
+  assert(e == 0);
+
+  e = js_destroy_env(env);
+  assert(e == 0);
+
+  e = js_destroy_platform(platform);
+  assert(e == 0);
+
+  e = uv_run(loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+}

--- a/test/inspector-heap-snapshot-report-progress.c
+++ b/test/inspector-heap-snapshot-report-progress.c
@@ -1,0 +1,136 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <utf.h>
+#include <uv.h>
+
+#include "../include/js.h"
+
+// Regression test for a crash when taking a heap snapshot with progress
+// reporting enabled. `HeapProfiler.takeHeapSnapshot` with `reportProgress: true`
+// causes V8 to emit `HeapProfiler.reportHeapSnapshotProgress` notifications from
+// within snapshot generation, while the stack is being scanned and JavaScript
+// execution is disallowed. If the inspector channel delivers those messages by
+// synchronously re-entering JavaScript (as a real embedder's callback does),
+// the process crashes. The runtime must instead defer delivery to a safe point.
+
+static js_ref_t *fn = NULL;
+
+static int progress_called = 0;
+static int chunk_called = 0;
+static int response_called = 0;
+
+static js_value_t *
+noop(js_env_t *env, js_callback_info_t *info) {
+  return NULL;
+}
+
+static void
+on_response(js_env_t *env, js_inspector_t *inspector, const char *message, size_t len, void *data) {
+  int e;
+
+  if (strstr(message, "reportHeapSnapshotProgress") != NULL) {
+    progress_called++;
+  } else if (strstr(message, "addHeapSnapshotChunk") != NULL) {
+    chunk_called++;
+  } else if (strstr(message, "\"id\":2") != NULL) {
+    response_called++;
+  }
+
+  // Re-enter JavaScript from the callback, exactly as an embedder that forwards
+  // inspector messages into a JS session does. On an unfixed runtime this call
+  // happens while snapshot generation forbids execution and crashes.
+  js_handle_scope_t *scope;
+  e = js_open_handle_scope(env, &scope);
+  assert(e == 0);
+
+  js_value_t *global;
+  e = js_get_global(env, &global);
+  assert(e == 0);
+
+  js_value_t *callback;
+  e = js_get_reference_value(env, fn, &callback);
+  assert(e == 0);
+
+  js_value_t *result;
+  e = js_call_function(env, global, callback, 0, NULL, &result);
+  assert(e == 0);
+
+  e = js_close_handle_scope(env, scope);
+  assert(e == 0);
+}
+
+int
+main() {
+  int e;
+
+  uv_loop_t *loop = uv_default_loop();
+
+  js_platform_t *platform;
+  e = js_create_platform(loop, NULL, &platform);
+  assert(e == 0);
+
+  js_env_t *env;
+  e = js_create_env(loop, platform, NULL, &env);
+  assert(e == 0);
+
+  js_handle_scope_t *scope;
+  e = js_open_handle_scope(env, &scope);
+  assert(e == 0);
+
+  js_value_t *callback;
+  e = js_create_function(env, "noop", -1, noop, NULL, &callback);
+  assert(e == 0);
+
+  e = js_create_reference(env, callback, 1, &fn);
+  assert(e == 0);
+
+  js_inspector_t *inspector;
+  e = js_create_inspector(env, &inspector);
+  assert(e == 0);
+
+  e = js_on_inspector_response(env, inspector, on_response, NULL);
+  assert(e == 0);
+
+  e = js_connect_inspector(env, inspector);
+  assert(e == 0);
+
+  const char *enable = "{ \"id\": 1, \"method\": \"HeapProfiler.enable\" }";
+
+  e = js_send_inspector_request(env, inspector, enable, -1);
+  assert(e == 0);
+
+  const char *snapshot = "{ \"id\": 2, \"method\": \"HeapProfiler.takeHeapSnapshot\", \"params\": { \"reportProgress\": true } }";
+
+  e = js_send_inspector_request(env, inspector, snapshot, -1);
+  assert(e == 0);
+
+  // Drive the loop so the scheduled snapshot task runs and its queued messages
+  // are delivered.
+  for (int i = 0; i < 10000 && response_called == 0; i++) {
+    uv_run(loop, UV_RUN_NOWAIT);
+  }
+
+  assert(progress_called > 0);
+  assert(chunk_called > 0);
+  assert(response_called == 1);
+
+  e = js_delete_reference(env, fn);
+  assert(e == 0);
+
+  e = js_destroy_inspector(env, inspector);
+  assert(e == 0);
+
+  e = js_close_handle_scope(env, scope);
+  assert(e == 0);
+
+  e = js_destroy_env(env);
+  assert(e == 0);
+
+  e = js_destroy_platform(platform);
+  assert(e == 0);
+
+  e = uv_run(loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+}

--- a/test/inspector-heap-snapshot-report-progress.c
+++ b/test/inspector-heap-snapshot-report-progress.c
@@ -7,14 +7,6 @@
 
 #include "../include/js.h"
 
-// Regression test for a crash when taking a heap snapshot with progress
-// reporting enabled. `HeapProfiler.takeHeapSnapshot` with `reportProgress: true`
-// causes V8 to emit `HeapProfiler.reportHeapSnapshotProgress` notifications from
-// within snapshot generation, while the stack is being scanned and JavaScript
-// execution is disallowed. If the inspector channel delivers those messages by
-// synchronously re-entering JavaScript (as a real embedder's callback does),
-// the process crashes. The runtime must instead defer delivery to a safe point.
-
 static js_ref_t *fn = NULL;
 
 static int progress_called = 0;


### PR DESCRIPTION
`HeapProfiler.takeHeapSnapshot` with `reportProgress: true` crashes the process with `SIGSEGV`. The inspector channel delivers V8 protocol messages by synchronously invoking the embedder callback, which re-enters JavaScript. During heap snapshot generation V8 emits `HeapProfiler.reportHeapSnapshotProgress` notifications while the stack is being scanned and JS execution is disallowed, so re-entering JS there crashes.

This makes the Chrome DevTools Memory panel unusable against an inspected process, since it requests progress reporting when taking a snapshot.

## Root cause

`js_inspector_channel_s::send()` used to call the response callback inline:

```c
cb(env, inspector, /* message */, len, data);
```

The crashing path (bare runtime, arm64):

```
  v8::internal::HeapSnapshotGenerator::GenerateSnapshot()
   └ PushAllRegistersAndIterateStack                 ← stack marker set, JS forbidden
     └ V8HeapExplorer::IterateAndExtractReferences
       └ reportHeapSnapshotProgress                  ← V8 emits the notification
         └ js_inspector_channel_s::send
           └ <embedder callback>
             └ v8::Function::Call                    💥 EXC_BAD_ACCESS (x9 = 0x0)
```

Omitting params, passing `{}`, or `reportProgress: false` all avoid the crash because they don't emit progress notifications mid-generation.

## Approach

Treat the channel as a deferred transport: `send()` never re-enters JavaScript, it only queues the (already converted) message. Delivery happens via `flush()` at the two points where re-entering JS is provably safe:

1. After `dispatchProtocolMessage()` in `js_inspector_s::send()`: responses to a client request are delivered synchronously, preserving the existing request/response behaviour (no observable change; existing tests untouched).
2. At the end of `js_env_s::run_macrotasks()` — notifications emitted from a V8 task (heap snapshot progress/chunks) are delivered between macrotasks.

`takeHeapSnapshot` schedules the snapshot as a task, so its messages aren't in the queue at point (1) and are delivered at point (2), out of the forbidden window.

Note on `flushProtocolNotifications()`: V8's own hook is left as a no-op on purpose. V8 calls it from `HeapSnapshotProgress::ReportProgressValue`  so delivering there would re-crash. 

Ref: https://gist.github.com/vietthang/3fa883343ff10a2ea4cf2a9b6a9e5b5b