### PR TITLE
Test that module specifiers reach the resolver verbatim

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -247,6 +247,7 @@ list(APPEND tests
   run-module-double-nested-import
   run-module-in-context
   run-module-nested-import
+  run-module-relative-import
   run-module-throw
   run-script
   run-script-ignore-return

--- a/test/run-module-relative-import.c
+++ b/test/run-module-relative-import.c
@@ -1,0 +1,89 @@
+#include <assert.h>
+#include <string.h>
+#include <utf.h>
+#include <uv.h>
+
+#include "../include/js.h"
+
+static js_module_t *foo;
+static js_module_t *bar;
+
+static js_module_t *
+on_module_resolve(js_env_t *env, js_value_t *specifier, js_value_t *assertions, js_module_t *referrer, void *data) {
+  int e;
+
+  utf8_t file[1024];
+  e = js_get_value_string_utf8(env, specifier, file, 1024, NULL);
+  assert(e == 0);
+
+  // The specifier must arrive exactly as written. Engines that resolve relative
+  // specifiers themselves would hand us something else, leaving the host unable
+  // to apply its own resolution.
+  assert(strcmp((char *) file, "./bar.js") == 0);
+
+  js_value_t *source;
+  e = js_create_string_utf8(env, (utf8_t *) "export default 42", -1, &source);
+  assert(e == 0);
+
+  e = js_create_module(env, "bar.js", -1, 0, source, NULL, NULL, &bar);
+  assert(e == 0);
+
+  return bar;
+}
+
+int
+main() {
+  int e;
+
+  uv_loop_t *loop = uv_default_loop();
+
+  js_platform_t *platform;
+  e = js_create_platform(loop, NULL, &platform);
+  assert(e == 0);
+
+  js_env_t *env;
+  e = js_create_env(loop, platform, NULL, &env);
+  assert(e == 0);
+
+  js_handle_scope_t *scope;
+  e = js_open_handle_scope(env, &scope);
+  assert(e == 0);
+
+  js_value_t *source;
+  e = js_create_string_utf8(env, (utf8_t *) "import bar from './bar.js'", -1, &source);
+  assert(e == 0);
+
+  e = js_create_module(env, "dir/foo.js", -1, 0, source, NULL, NULL, &foo);
+  assert(e == 0);
+
+  e = js_instantiate_module(env, foo, on_module_resolve, NULL);
+  assert(e == 0);
+
+  js_value_t *promise;
+  e = js_run_module(env, foo, &promise);
+  assert(e == 0);
+
+  js_promise_state_t state;
+  e = js_get_promise_state(env, promise, &state);
+  assert(e == 0);
+
+  assert(state == js_promise_fulfilled);
+
+  e = js_delete_module(env, foo);
+  assert(e == 0);
+
+  e = js_delete_module(env, bar);
+  assert(e == 0);
+
+  e = js_close_handle_scope(env, scope);
+  assert(e == 0);
+
+  e = js_destroy_env(env);
+  assert(e == 0);
+
+  e = js_destroy_platform(platform);
+  assert(e == 0);
+
+  e = uv_run(loop, UV_RUN_DEFAULT);
+  assert(e == 0);
+}


### PR DESCRIPTION
Every existing module test imports a bare specifier (`import bar from 'bar.js'`). Engines differ in how they treat *relative* specifiers: some hand the host resolver exactly what was written, others resolve them first. Nothing in the suite distinguishes the two, so a backend that rewrites specifiers passes CI while denying the host the ability to run its own resolution.

This adds `run-module-relative-import`, which mirrors `run-module-nested-import` but imports `'./bar.js'` from a module named `dir/foo.js` and asserts the specifier arrives unchanged.

### Why it matters

holepunchto/libqjs#25: libqjs left QuickJS's default normalizer in place, which joins any specifier starting with `.` to the referrer's directory. The host therefore received an already-resolved path and skipped extension resolution, so `import mod from './fixtures/mjs'` failed in Bare while `require()` of the same path worked. libqjs's suite stayed green throughout, because this case wasn't covered.

### Verification

Run against libqjs, which shares this suite:

- without holepunchto/libqjs#27: **fails** — `Assertion failed: (strcmp((char *) file, "./bar.js") == 0)`
- with holepunchto/libqjs#27: **passes**

So it catches the specific defect it's meant to.

I have not built libjs standalone to confirm it passes on V8 — that needs a full GN build of V8. The behaviour is not in doubt: V8 hands `ResolveModuleCallback` the specifier straight from the module record with no host-side rewriting, which is why Bare resolves relative imports correctly on the default backend and only broke on QuickJS. Worth a CI run to confirm rather than taking my word for it.
